### PR TITLE
Set attributes when creating model from database

### DIFF
--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -36,6 +36,7 @@ abstract class BaseModel implements \JsonSerializable
      */
     public function setAttributes(array $attributes = [])
     {
+        $this->attributes = $attributes;
         foreach ($attributes as $key => $value) {
             if (property_exists(static::class, $key)) {
                 $this->$key = $value;


### PR DESCRIPTION
A bugfix for a problem where repositories return models with no set attributes hash, which causes the objects to be serialized to `null`.